### PR TITLE
MILAB-3015 add format annotations

### DIFF
--- a/.changeset/polite-memes-attend.md
+++ b/.changeset/polite-memes-attend.md
@@ -1,0 +1,5 @@
+---
+'@platforma-open/milaboratories.differential-expression.workflow': minor
+---
+
+Add number formatting annotations

--- a/workflow/src/DEGPfconvParams.lib.tengo
+++ b/workflow/src/DEGPfconvParams.lib.tengo
@@ -31,7 +31,8 @@ getColumns := func(countsSpec) {
 					"valueType": "Double",
 					"annotations": {
 						"pl7.app/label": "Log2FC",
-						"pl7.app/table/orderPriority": "60"
+						"pl7.app/table/orderPriority": "60",
+						"pl7.app/format": ".2f"
 					}
 				}
 			},

--- a/workflow/src/topTablePfconvParams.lib.tengo
+++ b/workflow/src/topTablePfconvParams.lib.tengo
@@ -37,7 +37,8 @@ getColumns := func(countsSpec, log2FCThreshold, pAdjFCThreshold) {
 					"valueType": "Double",
 					"annotations": {
 						"pl7.app/label": "Base mean",
-						"pl7.app/table/orderPriority": "70"
+						"pl7.app/table/orderPriority": "70",
+						"pl7.app/format": ".2f"
 					}
 				}
 			},
@@ -51,7 +52,8 @@ getColumns := func(countsSpec, log2FCThreshold, pAdjFCThreshold) {
 					"annotations": {
 						"pl7.app/label": "Log2FC",
 						"pl7.app/table/orderPriority": "60",
-						"pl7.app/graph/axis/symmetricRange": "0"
+						"pl7.app/graph/axis/symmetricRange": "0",
+						"pl7.app/format": ".2f"
 					}
 				}
 			},
@@ -64,7 +66,8 @@ getColumns := func(countsSpec, log2FCThreshold, pAdjFCThreshold) {
 					"valueType": "Double",
 					"annotations": {
 						"pl7.app/label": "Log2FC SE",
-						"pl7.app/table/orderPriority": "50"
+						"pl7.app/table/orderPriority": "50",
+						"pl7.app/format": ".2f"
 					}
 				}
 			},
@@ -77,7 +80,8 @@ getColumns := func(countsSpec, log2FCThreshold, pAdjFCThreshold) {
 					"valueType": "Double",
 					"annotations": {
 						"pl7.app/label": "Stat",
-						"pl7.app/table/orderPriority": "40"
+						"pl7.app/table/orderPriority": "40",
+						"pl7.app/format": ".2f"
 					}
 				}
 			},
@@ -90,7 +94,8 @@ getColumns := func(countsSpec, log2FCThreshold, pAdjFCThreshold) {
 					"valueType": "Double",
 					"annotations": {
 						"pl7.app/label": "P-value",
-						"pl7.app/table/orderPriority": "30"
+						"pl7.app/table/orderPriority": "30",
+						"pl7.app/format": ".2e"
 					}
 				}
 			},
@@ -103,7 +108,8 @@ getColumns := func(countsSpec, log2FCThreshold, pAdjFCThreshold) {
 					"valueType": "Double",
 					"annotations": {
 						"pl7.app/label": "Adjusted p-value",
-						"pl7.app/table/orderPriority": "20"
+						"pl7.app/table/orderPriority": "20",
+						"pl7.app/format": ".2e"
 					}
 				}
 			},
@@ -116,7 +122,8 @@ getColumns := func(countsSpec, log2FCThreshold, pAdjFCThreshold) {
 					"valueType": "Double",
 					"annotations": {
 						"pl7.app/label": "-log10 adjusted p-value",
-						"pl7.app/table/orderPriority": "10"
+						"pl7.app/table/orderPriority": "10",
+						"pl7.app/format": ".2f"
 					}
 				}
 			},


### PR DESCRIPTION
Notations used:
- .2f (fixed point with 2 decimal places)
- .2e (scientific notation with 2 decimal places)

For main table:
baseMean - .2f
log2FoldChange - .2f
lfcSE (Log2FC Standard Error) - .2f
stat (Wald statistic) - .2f
pvalue - .2e 
padj (adjusted p-value) - .2e 
minlog10padj (-log10 adjusted p-value) - .2f 


Exports:
log2FoldChange - .2f