### PR TITLE
MILAB-6263: fix renv runtime permission-denied on non-root containers

### DIFF
--- a/.changeset/fix-runtime-renv-restore-permission-denied.md
+++ b/.changeset/fix-runtime-renv-restore-permission-denied.md
@@ -1,0 +1,5 @@
+---
+"@platforma-open/milaboratories.run-deseq2-r.software": patch
+---
+
+Fix runtime `Permission denied` when the container runs as a non-root UID (MILAB-6263). The entrypoint re-invoked `renv::restore()` on every start, which tries to reconcile the system R library at `/usr/local/lib/R/site-library/` with the project lockfile. When the `r-base:4.4.2` base image preinstalled a version of a locked package (e.g. `rlang`) that differs from `renv.lock`, renv attempted to back up the system-library copy before replacing it — failing on hosts that run the container unprivileged. renv now installs into a project-local library at `/app/renv/library` and `R_LIBS_USER` points R at the same path, so the obsolete `/app/run.sh` wrapper and runtime restore are removed.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -22,8 +22,8 @@ catalogs:
       specifier: ~1.0.7
       version: 1.0.7
     '@platforma-sdk/block-tools':
-      specifier: ~2.6.30
-      version: 2.6.30
+      specifier: ~2.7.24
+      version: 2.7.24
     '@platforma-sdk/blocks-deps-updater':
       specifier: ~2.0.0
       version: 2.0.0
@@ -110,7 +110,7 @@ importers:
     devDependencies:
       '@platforma-sdk/block-tools':
         specifier: 'catalog:'
-        version: 2.6.30
+        version: 2.7.24
 
   model:
     dependencies:
@@ -123,7 +123,7 @@ importers:
     devDependencies:
       '@platforma-sdk/block-tools':
         specifier: 'catalog:'
-        version: 2.6.30
+        version: 2.7.24
       '@platforma-sdk/eslint-config':
         specifier: 'catalog:'
         version: 1.1.0(@eslint/js@9.20.0)(@stylistic/eslint-plugin@2.13.0(eslint@9.20.1)(typescript@5.5.4))(eslint-plugin-n@17.15.1(eslint@9.20.1))(eslint-plugin-vue@9.32.0(eslint@9.20.1))(eslint@9.20.1)(globals@15.15.0)(typescript-eslint@8.24.1(eslint@9.20.1)(typescript@5.5.4))(typescript@5.5.4)
@@ -1099,6 +1099,10 @@ packages:
     resolution: {integrity: sha512-Eg3AQMJbVClYhdvhogdlW3Ys9EdLLl8ZTqG675iLwoO64ZJcQOAnIPjXwl4zJ/bZWx4nEhRF9AvwxRdc08fikQ==}
     engines: {node: '>=22'}
 
+  '@milaboratories/helpers@1.14.2':
+    resolution: {integrity: sha512-zOkD4aWNbembwI+AsPTz7nmWC1VPA4rwGBc+Nd5jPpKVh7rCtZwQrlOP5mVqRVMKIAjb1nU8kzzCGfqNPqfJjA==}
+    engines: {node: '>=22'}
+
   '@milaboratories/miplots4@1.0.158':
     resolution: {integrity: sha512-M3EG2qhiDKAYg3DGhmn3y/m0Or54A0R0oIX8W9WNxHc5/TP+kEggiGfHt/GZUmDrjhAHk38UDMEDELKD7zX5AQ==}
 
@@ -1131,6 +1135,9 @@ packages:
     resolution: {integrity: sha512-PaodjOX6GSvwEQEL/L0VKPuqo0V0chD1pBWYPnXRzCRs2zImRMopJzAMNS9Hj0NFOcmZb2+MFi6TaEtjmgLiow==}
     engines: {node: '>=22'}
 
+  '@milaboratories/pl-error-like@1.12.10':
+    resolution: {integrity: sha512-iHmnLG5lxJqcymUmEL8onCDGEADk1S/5RNACQ5yfTCNcCkUc+7hYrDHQpFmWXPPGC9sG+NTBxt4wr5m8UsLm2g==}
+
   '@milaboratories/pl-error-like@1.12.5':
     resolution: {integrity: sha512-opYP4OrB6JBMsH9RMRmAH44+MG7PWiV08dHW9+RsXGOaqX+rYXs9TTBXYRhlVMDLwwefSKzelvDg8HL748aM+A==}
 
@@ -1139,6 +1146,9 @@ packages:
 
   '@milaboratories/pl-http@1.2.0':
     resolution: {integrity: sha512-5iRxug4TjE88+XoMU5LVcXe1PEmXYfZI3WxJGrayzYQFM/9GiKuwcUsQ0kDlFmw+s6UlEAzgC9+MsJFKvU7C5Q==}
+
+  '@milaboratories/pl-http@1.2.4':
+    resolution: {integrity: sha512-QKmhx+WEvJCV9dUy/SBdQk/ApaJ5ewBFgm/b+XPlS10SusAdqUUTGvK5+hq8YSuUMXlHb/dk++UtI5YlDuDl2Q==}
 
   '@milaboratories/pl-middle-layer@1.43.67':
     resolution: {integrity: sha512-cx7Dbjjzj6924KKYqqNvEhCKeHW0ZVvDSYlA6UQ/cIsSgXhSTpCxom43gbRNqBsopOr3L+OdRB0U4G9iFNRexQ==}
@@ -1156,8 +1166,11 @@ packages:
   '@milaboratories/pl-model-common@1.24.0':
     resolution: {integrity: sha512-aKYexA27Qq2rooQu+QhFmZLyu+pdhaA6xkbDeV2qbofZrIfkeHvmcl7Ovh7syafndGhdBCJfZjWXgbbD9jJYDw==}
 
-  '@milaboratories/pl-model-middle-layer@1.10.0':
-    resolution: {integrity: sha512-EkYw3rljpm/i+i6x8ZYzIMDO/7yMst4xF5uMvMgnZC7ulDs7tURc/A5Fsl3fsxNI53bPFtBjYGMElI3ardECUA==}
+  '@milaboratories/pl-model-common@1.41.2':
+    resolution: {integrity: sha512-gp4P0+MNF+u1DcbO+clIbRy4bIHkZrixsQ4rOEE0ln8gWdWy6tN25MdbrWYaobYOWh8TupeH+rzCOSRbK5ubQg==}
+
+  '@milaboratories/pl-model-middle-layer@1.19.3':
+    resolution: {integrity: sha512-MurcKSqJSPsc3uAUaK5o4STDY+Nvl1prd1aF1UlMWsxLKn3pXd+Aoa3I1W8q3jraQRHSfE3efNPWD0/uJueMPw==}
 
   '@milaboratories/pl-model-middle-layer@1.8.35':
     resolution: {integrity: sha512-fNYE4nWcmDn5CAK7IOwSR9htq10F7mPpfIunEcOHDXS1pSrPxc+QGiw6fJRWcV4KE8Qt55xfmmrl0zO/r2aCvg==}
@@ -1178,6 +1191,9 @@ packages:
   '@milaboratories/resolve-helper@1.1.2':
     resolution: {integrity: sha512-xicajvqgaGOdXlKwolwVHdXNB3zRUbvjIiZQWcy2R+3rbScfEaBspnDDstDXKc4nMbieO+8Bq2o7AbtKmheDfw==}
 
+  '@milaboratories/resolve-helper@1.1.3':
+    resolution: {integrity: sha512-38/dW/XRZQREOxAOOKtO0lzEWPCP/DH0qhB3q1kYcGoN++5V92/zbVwbYrMDeDcjTyo+D62iIep+sKXeWHa7Uw==}
+
   '@milaboratories/software-pframes-conv@2.2.9':
     resolution: {integrity: sha512-w+GaazDSqEgqYUJ38I5lgOsggyZJpcBVGvDMHIX1pyTdvPjWAOWu3mLkScaYuWeitFfh8aAedf5vrLqXtnX8bw==}
 
@@ -1189,15 +1205,15 @@ packages:
   '@milaboratories/ts-helpers-oclif@1.1.33':
     resolution: {integrity: sha512-1200VRTW3L5GNvjAiBXrsbLnvMGycuiyXMa6WyY154wk8D3oERaOCpzUDNtTDIf+QnXmJNrc9GSlI4940eCl7A==}
 
-  '@milaboratories/ts-helpers-oclif@1.1.34':
-    resolution: {integrity: sha512-humrdxHUj4++/3IYnpHC7x2l9W1q/+jltMdc+QWa9zwZR1vX8JIu6VgBMoYRRXfu/lpxzwKaddGTlh8QKUL+FQ==}
+  '@milaboratories/ts-helpers-oclif@1.1.41':
+    resolution: {integrity: sha512-rpn1jB2b6p4hcw4Y2iuLM/9X9zqGXacRL1RbZMaB6ebk+2bnmH3CtmfJJdBWW1wfsP80HqmRV8iQrfCI1kzFDA==}
 
   '@milaboratories/ts-helpers@1.5.4':
     resolution: {integrity: sha512-Inpyk9sYn1e+59KwgAQW9uFBIR6hmMozDgTfOmz7sx38a2ZftBkYQtSCHwzztbV5tg8covugxbFEbpDKfDDF6A==}
     engines: {node: '>=22.19.0'}
 
-  '@milaboratories/ts-helpers@1.6.0':
-    resolution: {integrity: sha512-/IE/bkICWkNzbFgU8UEkuVG58crBUl4EOTtT8lzToIRVOU0LfLJwdTZqJgCurmgpaU2rlI02xtlzhg+G7cU0vQ==}
+  '@milaboratories/ts-helpers@1.8.2':
+    resolution: {integrity: sha512-bQHcEAeJXyV95Gyk0yoRS5t3M71mFaNG+SsY2o+i4GDDeByUXBiF+T5A0elc/rCyLK6NNlOblou0DHBYOiW3pQ==}
     engines: {node: '>=22.19.0'}
 
   '@milaboratories/uikit@2.6.2':
@@ -1296,12 +1312,16 @@ packages:
     resolution: {integrity: sha512-/GR3mTsfZcTVX1lX2uPiOBe06FN78xmcRiViR164FCI2yt8pFAz88wpI9LyGiRJh/fM8dE2jHXn0V76PniAFMA==}
     hasBin: true
 
-  '@platforma-sdk/block-tools@2.6.30':
-    resolution: {integrity: sha512-Kkkuap5YL7Gt6J56pcABy6U1LEmMCnwt5kVVqBQm+VdDl+uu2erOlfgBBzna8ebsECOiJUM23PU7yj9BeJL6Fw==}
+  '@platforma-sdk/block-tools@2.7.24':
+    resolution: {integrity: sha512-k4eDQS+RD6u1/WAysGiHcGY5szgTLyBYC4PJ6d3uX6pep2XCa2nh6JRD+kWNqaxZ7oQAZidNWxZkbCGiqEbe0g==}
     hasBin: true
 
   '@platforma-sdk/blocks-deps-updater@2.0.0':
     resolution: {integrity: sha512-cef5ysA011ub5bofbWQJ3EM9rZ7A4ixGMKhFIsF2VNwYrCu5XRHsayA6vDeFOBjX4Jnq9D0QztW0JUxXD73bpw==}
+    hasBin: true
+
+  '@platforma-sdk/blocks-deps-updater@2.2.0':
+    resolution: {integrity: sha512-p9lBxhFXM9WoRsrJO7dfkiXSK+1m63yIn1sKhBO71eMbhrLMyVYHEOeNf3w5OCdbRF5QsNhXzWuiTmFK3zHFsA==}
     hasBin: true
 
   '@platforma-sdk/eslint-config@1.1.0':
@@ -5579,6 +5599,9 @@ packages:
   zod@3.23.8:
     resolution: {integrity: sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g==}
 
+  zod@3.25.76:
+    resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
+
   zod@4.1.12:
     resolution: {integrity: sha512-JInaHOamG8pt5+Ey8kGmdcAcg3OL9reK8ltczgHTAwNhMys/6ThXHityHxVV2p3fkw/c+MAvBHFVYHFZDmjMCQ==}
 
@@ -6722,6 +6745,8 @@ snapshots:
 
   '@milaboratories/helpers@1.12.0': {}
 
+  '@milaboratories/helpers@1.14.2': {}
+
   '@milaboratories/miplots4@1.0.158(d3-dispatch@3.0.1)(d3-path@3.1.0)(d3-scale-chromatic@3.1.0)':
     dependencies:
       '@d3fc/d3fc-chart': 5.1.9(d3-array@3.2.4)(d3-path@3.1.0)(d3-scale-chromatic@3.1.0)(d3-scale@4.0.2)(d3-selection@3.0.0)(d3-shape@3.2.0)
@@ -6863,6 +6888,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@milaboratories/pl-error-like@1.12.10':
+    dependencies:
+      json-stringify-safe: 5.0.1
+      zod: 3.25.76
+
   '@milaboratories/pl-error-like@1.12.5':
     dependencies:
       canonicalize: 2.1.0
@@ -6883,6 +6913,10 @@ snapshots:
       undici: 7.16.0
     transitivePeerDependencies:
       - supports-color
+
+  '@milaboratories/pl-http@1.2.4':
+    dependencies:
+      undici: 7.16.0
 
   '@milaboratories/pl-middle-layer@1.43.67':
     dependencies:
@@ -6944,12 +6978,20 @@ snapshots:
       canonicalize: 2.1.0
       zod: 3.23.8
 
-  '@milaboratories/pl-model-middle-layer@1.10.0':
+  '@milaboratories/pl-model-common@1.41.2':
     dependencies:
-      '@milaboratories/pl-model-common': 1.24.0
-      remeda: 2.31.1
+      '@milaboratories/helpers': 1.14.2
+      '@milaboratories/pl-error-like': 1.12.10
+      canonicalize: 2.1.0
+      zod: 3.25.76
+
+  '@milaboratories/pl-model-middle-layer@1.19.3':
+    dependencies:
+      '@milaboratories/helpers': 1.14.2
+      '@milaboratories/pl-model-common': 1.41.2
+      es-toolkit: 1.39.10
       utility-types: 3.11.0
-      zod: 3.23.8
+      zod: 3.25.76
 
   '@milaboratories/pl-model-middle-layer@1.8.35':
     dependencies:
@@ -6986,6 +7028,8 @@ snapshots:
 
   '@milaboratories/resolve-helper@1.1.2': {}
 
+  '@milaboratories/resolve-helper@1.1.3': {}
+
   '@milaboratories/software-pframes-conv@2.2.9': {}
 
   '@milaboratories/tengo-tester@1.6.4': {}
@@ -6995,9 +7039,9 @@ snapshots:
       '@milaboratories/ts-helpers': 1.5.4
       '@oclif/core': 4.0.37
 
-  '@milaboratories/ts-helpers-oclif@1.1.34':
+  '@milaboratories/ts-helpers-oclif@1.1.41':
     dependencies:
-      '@milaboratories/ts-helpers': 1.6.0
+      '@milaboratories/ts-helpers': 1.8.2
       '@oclif/core': 4.0.37
 
   '@milaboratories/ts-helpers@1.5.4':
@@ -7005,8 +7049,9 @@ snapshots:
       canonicalize: 2.1.0
       denque: 2.1.0
 
-  '@milaboratories/ts-helpers@1.6.0':
+  '@milaboratories/ts-helpers@1.8.2':
     dependencies:
+      '@milaboratories/helpers': 1.14.2
       canonicalize: 2.1.0
       denque: 2.1.0
 
@@ -7168,30 +7213,32 @@ snapshots:
       - aws-crt
       - supports-color
 
-  '@platforma-sdk/block-tools@2.6.30':
+  '@platforma-sdk/block-tools@2.7.24':
     dependencies:
       '@aws-sdk/client-s3': 3.859.0
-      '@milaboratories/pl-http': 1.2.0
-      '@milaboratories/pl-model-common': 1.24.0
-      '@milaboratories/pl-model-middle-layer': 1.10.0
-      '@milaboratories/resolve-helper': 1.1.1
-      '@milaboratories/ts-helpers': 1.6.0
-      '@milaboratories/ts-helpers-oclif': 1.1.34
+      '@milaboratories/pl-http': 1.2.4
+      '@milaboratories/pl-model-common': 1.41.2
+      '@milaboratories/pl-model-middle-layer': 1.19.3
+      '@milaboratories/resolve-helper': 1.1.3
+      '@milaboratories/ts-helpers': 1.8.2
+      '@milaboratories/ts-helpers-oclif': 1.1.41
       '@oclif/core': 4.0.37
-      '@platforma-sdk/blocks-deps-updater': 2.0.0
+      '@platforma-sdk/blocks-deps-updater': 2.2.0
       canonicalize: 2.1.0
       lru-cache: 11.2.2
       mime-types: 2.1.35
-      remeda: 2.31.1
       tar: 7.4.3
       undici: 7.16.0
       yaml: 2.8.1
-      zod: 3.23.8
+      zod: 3.25.76
     transitivePeerDependencies:
       - aws-crt
-      - supports-color
 
   '@platforma-sdk/blocks-deps-updater@2.0.0':
+    dependencies:
+      yaml: 2.8.1
+
+  '@platforma-sdk/blocks-deps-updater@2.2.0':
     dependencies:
       yaml: 2.8.1
 
@@ -12302,5 +12349,7 @@ snapshots:
       readable-stream: 4.7.0
 
   zod@3.23.8: {}
+
+  zod@3.25.76: {}
 
   zod@4.1.12: {}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -7,7 +7,7 @@ packages:
   - test
 
 catalog:
-  '@platforma-sdk/block-tools': ~2.6.30
+  '@platforma-sdk/block-tools': ~2.7.24
   '@platforma-sdk/model': ~1.45.35
   '@platforma-sdk/ui-vue': ~1.45.36
   '@platforma-sdk/tengo-builder': ~2.3.10

--- a/software/Dockerfile
+++ b/software/Dockerfile
@@ -8,31 +8,31 @@ ENV RENV_CONFIG_REPOS_OVERRIDE=https://cloud.r-project.org
 
 # Install system dependencies required for R packages
 RUN apt-get update && apt-get install -y \
-    curl \
     ca-certificates \
+    curl \
     dash \
-    libcurl4-openssl-dev \
-    libssl-dev \
-    libxml2-dev \
-    libcairo2-dev \
-    libgit2-dev \
     default-libmysqlclient-dev \
+    libbz2-dev \
+    libcairo2-dev \
+    libcurl4-openssl-dev \
+    libfreetype6-dev \
+    libfribidi-dev \
+    libgit2-dev \
+    libgsl-dev \
+    libharfbuzz-dev \
+    libjpeg-dev \
+    liblzma-dev \
+    libpcre2-dev \
+    libpng-dev \
     libpq-dev \
     libsasl2-dev \
     libsqlite3-dev \
     libssh2-1-dev \
-    unixodbc-dev \
-    libharfbuzz-dev \
-    libfribidi-dev \
-    libfreetype6-dev \
-    libpng-dev \
+    libssl-dev \
     libtiff5-dev \
-    libjpeg-dev \
-    libgsl-dev \
-    libbz2-dev \
-    liblzma-dev \
-    libpcre2-dev \
     libuv1-dev \
+    libxml2-dev \
+    unixodbc-dev \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
@@ -65,4 +65,5 @@ RUN mkdir -p "${R_LIBS_USER}"
 # (e.g. ggplot2 starting before tibble is visible in the library).
 RUN R --no-echo -e "tryCatch(renv::restore(), error = function(e) message('parallel pass finished with errors: ', conditionMessage(e))); options(Ncpus = 1); renv::restore(clean = TRUE)" \
     && find /root/.cache/R -name keys.html -delete \
-    && find /usr/local/lib/R -name keys.html -delete
+    && find /usr/local/lib/R -name keys.html -delete \
+    && find "${R_LIBS_USER}" -name keys.html -delete

--- a/software/Dockerfile
+++ b/software/Dockerfile
@@ -48,12 +48,15 @@ COPY ./renv.lock ./renv.lock
 ENV RENV_PATHS_RENV=/app/renv
 ENV RENV_PATHS_LOCKFILE=/app/renv.lock
 
+# Direct renv to install into a project-local library (instead of the
+# system-wide /usr/local/lib/R/site-library) and expose that path to R via
+# R_LIBS_USER so Rscript finds the packages at runtime without any renv code.
+ENV R_LIBS_USER=/app/renv/library
+ENV RENV_PATHS_LIBRARY=${R_LIBS_USER}
+
+# Yes, we have to create it manually. Otherwise default will be used silently.
+RUN mkdir -p "${R_LIBS_USER}"
+
 RUN R --no-echo -e "renv::restore(clean = TRUE)" \
     && find /root/.cache/R -name keys.html -delete \
     && find /usr/local/lib/R -name keys.html -delete
-
-RUN echo "#!/bin/bash\nR --no-echo --no-restore -e \"renv::restore()\"\n\"\$@\"" > /app/run.sh
-RUN chmod +x /app/run.sh
-
-# Default command runs Rscript
-ENTRYPOINT ["/app/run.sh"]

--- a/software/Dockerfile
+++ b/software/Dockerfile
@@ -57,6 +57,9 @@ ENV RENV_PATHS_LIBRARY=${R_LIBS_USER}
 # Yes, we have to create it manually. Otherwise default will be used silently.
 RUN mkdir -p "${R_LIBS_USER}"
 
-RUN R --no-echo -e "renv::restore(clean = TRUE)" \
+# First pass: parallel install (fast for the bulk of packages).
+# Second pass: sequential retry to resolve any parallel-install races
+# (e.g. ggplot2 starting before tibble is visible in the library).
+RUN R --no-echo -e "tryCatch(renv::restore(), error = function(e) message('parallel pass finished with errors: ', conditionMessage(e))); options(Ncpus = 1); renv::restore(clean = TRUE)" \
     && find /root/.cache/R -name keys.html -delete \
     && find /usr/local/lib/R -name keys.html -delete

--- a/software/Dockerfile
+++ b/software/Dockerfile
@@ -8,6 +8,8 @@ ENV RENV_CONFIG_REPOS_OVERRIDE=https://cloud.r-project.org
 
 # Install system dependencies required for R packages
 RUN apt-get update && apt-get install -y \
+    curl \
+    ca-certificates \
     dash \
     libcurl4-openssl-dev \
     libssl-dev \
@@ -30,6 +32,7 @@ RUN apt-get update && apt-get install -y \
     libbz2-dev \
     liblzma-dev \
     libpcre2-dev \
+    libuv1-dev \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
## Summary
Cross-block fix: the docker entrypoint of the R-based software re-ran `renv::restore()` on every container start. On hosts that run the container as a non-root UID (e.g. lab.research), renv tried to back up entries in the root-owned `/usr/local/lib/R/site-library/` (e.g. `rlang` brought in by the `r-base:4.4.2` base image) and failed with `Permission denied`.

Already merged in `differential-clonotype-abundance` (platforma-open/differential-clonotype-abundance#43); the same `Dockerfile` pattern was replicated here.

## Change
- `ENV R_LIBS_USER=/app/renv/library` + `ENV RENV_PATHS_LIBRARY=\${R_LIBS_USER}` so renv installs into a project-local library and R discovers packages via the standard `R_LIBS_USER` env var.
- `RUN mkdir -p \"\${R_LIBS_USER}\"` because renv silently falls back to the default library if the path doesn't exist.
- Drop `/app/run.sh` and the `ENTRYPOINT`; the platforma SDK passes the full `cmd` (`Rscript /app/...`) at run time, so no wrapper is needed.

## Test plan
- [ ] CI build of the docker image succeeds.
- [ ] On a non-root host (lab.research), running the entrypoint no longer logs `cannot create directory '/usr/local/lib/R/site-library/...': Permission denied`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR fixes a `Permission denied` crash that occurred when running the DESeq2 R container as a non-root user: the old entrypoint re-ran `renv::restore()` at startup, which tried to back up root-owned system-library packages before replacing them. The fix redirects renv's library to `/app/renv/library` (writable at runtime), removes the now-unnecessary `run.sh` wrapper and `ENTRYPOINT`, and performs a two-pass build-time restore to handle parallel-install races.

- `ENV R_LIBS_USER=/app/renv/library` + `ENV RENV_PATHS_LIBRARY=${R_LIBS_USER}` route all renv package installs to a project-local, writable path; R finds packages there via the standard `R_LIBS_USER` mechanism at runtime without any renv involvement.
- A parallel-then-sequential two-pass `renv::restore()` strategy is introduced at build time to work around package visibility races (e.g. ggplot2 starting before tibble is fully installed).
- `@platforma-sdk/block-tools` is bumped from `2.6.30` to `2.7.24` with corresponding lockfile and transitive-dependency updates.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge; the Dockerfile fix is targeted and well-reasoned, and the pnpm changes are routine dependency upgrades.

The core permission fix is correct and mirrors a sibling repo that already merged it. The two-pass restore strategy works but silently swallows first-pass errors, making build failures harder to diagnose; the renv cache is also not fully purged, leaving unneeded build artifacts in the image layer.

software/Dockerfile — the two-pass renv restore logic and post-install cache cleanup are the only areas worth a second look.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| software/Dockerfile | Redirects renv library to /app/renv/library via R_LIBS_USER + RENV_PATHS_LIBRARY, removes the run.sh entrypoint wrapper, and introduces a two-pass install strategy to handle parallel-install races. |
| pnpm-workspace.yaml | Bumps @platforma-sdk/block-tools catalog pin from ~2.6.30 to ~2.7.24. |
| pnpm-lock.yaml | Auto-generated lockfile update reflecting block-tools bump and its transitive dependency changes (pl-model-common, pl-model-middle-layer, ts-helpers, zod, etc.). |
| .changeset/fix-runtime-renv-restore-permission-denied.md | Changeset entry tagging the software package as a patch release with a clear description of the permission-denied root cause. |

</details>

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant D as Docker Build
    participant renv as renv (R)
    participant lib as /app/renv/library
    participant cache as /root/.cache/R/renv

    D->>renv: "Pass 1 – renv::restore() (parallel, Ncpus > 1)"
    renv->>cache: "Download & cache tarballs"
    renv->>lib: Install packages (parallel)
    note over renv: tryCatch – errors become messages only

    D->>renv: "Pass 2 – renv::restore(clean=TRUE) (Ncpus=1)"
    renv->>cache: Re-use cached tarballs
    renv->>lib: Reinstall missing / fix races (sequential)

    D->>D: find … -name keys.html -delete (cleanup)

    note over D,lib: Runtime – SDK provides full Rscript cmd
    participant sdk as Platforma SDK
    participant ctr as Container (non-root UID)
    sdk->>ctr: docker run … Rscript /app/…
    ctr->>lib: "R_LIBS_USER=/app/renv/library → packages found, no renv needed"
```
</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
software/Dockerfile:66-68
The renv global package cache under `/root/.cache/R/renv` is not purged after installation — only the small `keys.html` index files are removed. The cached tarballs, extracted sources, and build artifacts remain in the layer, adding unnecessary bulk to the final image. Consider deleting the entire cache directory after the restore to keep the image lean.

```suggestion
RUN R --no-echo -e "tryCatch(renv::restore(), error = function(e) message('parallel pass finished with errors: ', conditionMessage(e))); options(Ncpus = 1); renv::restore(clean = TRUE)" \
    && find /root/.cache/R -name keys.html -delete \
    && find /usr/local/lib/R -name keys.html -delete \
    && rm -rf /root/.cache/R/renv
```

### Issue 2 of 2
software/Dockerfile:66
**First-pass errors are silently swallowed**

The `tryCatch` in the first pass converts any `renv::restore()` error into a plain `message()`, so failures caused by transient network issues, missing system libraries, or a corrupt lockfile during the parallel phase will not be visible in the build log as errors — they will only appear as a printed message. The second sequential pass will then surface the real failure, but only after re-attempting every package, which can obscure the root cause and waste significant build time. If surfacing the first-pass failure sooner is acceptable, a `warning()` instead of `message()` would at least make it more conspicuous, though it still won't halt the build.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["MILAB-6263: align Dockerfile across all ..."](https://github.com/platforma-open/differential-expression/commit/1fd2760cee63ebeaa72a506b6fb58fdc2065a852) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31796215)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->